### PR TITLE
StatefulProperty Fix

### DIFF
--- a/src/Mikulas/OrmExt/MappingFactory.php
+++ b/src/Mikulas/OrmExt/MappingFactory.php
@@ -35,7 +35,7 @@ class MappingFactory
 	{
 		$this->validateProperty($propertyName);
 
-		$this->storageReflection->addMapping(
+		$this->storageReflection->setMapping(
 			$propertyName,
 			$this->storageReflection->convertEntityToStorageKey($propertyName),
 			function ($value) {
@@ -58,7 +58,7 @@ class MappingFactory
 	{
 		$this->validateProperty($propertyName);
 
-		$this->storageReflection->addMapping(
+		$this->storageReflection->setMapping(
 			$propertyName,
 			$this->storageReflection->convertEntityToStorageKey($propertyName) . $sqlPostfix,
 			function ($garble) use ($crypto) {
@@ -81,7 +81,7 @@ class MappingFactory
 	{
 		$this->validateProperty($propertyName);
 
-		$this->storageReflection->addMapping(
+		$this->storageReflection->setMapping(
 			$propertyName,
 			$this->storageReflection->convertEntityToStorageKey($propertyName),
 			function ($value) use ($toEntityTransform) {

--- a/src/Mikulas/OrmExt/StatefulProperty.php
+++ b/src/Mikulas/OrmExt/StatefulProperty.php
@@ -32,12 +32,12 @@ abstract class StatefulProperty extends ModifiableDataStore implements StatefulI
 		$this->stateMachine = new StateMachine($this);
 		$this->getLoader()->load($this->stateMachine);
 
+		$this->setFiniteState($state ?: $this->getInitialState());
+		$this->onModify();
+
 		// intentionally set after ArrayLoader::load, as it sets symfony accessor
 		$this->stateMachine->setStateAccessor(new StatefulPropertyStateAccessor);
 		$this->stateMachine->initialize();
-
-		$this->setFiniteState($state ?: $this->getInitialState());
-		$this->onModify();
 	}
 
 

--- a/tests/cases/integration/StatefulPropertyTest.phpt
+++ b/tests/cases/integration/StatefulPropertyTest.phpt
@@ -53,6 +53,13 @@ class StatefulPropertyTest extends TestCase
 		self::assertState(MaritalStatus::MARRIED, $person);
 	}
 
+
+	public function testCreateStatusWithNonInitialState()
+	{
+		$status = new MaritalStatus(MaritalStatus::MARRIED);
+		Assert::same(MaritalStatus::MARRIED, $status->getStateMachine()->getCurrentState()->getName());
+	}
+
 }
 
 (new StatefulPropertyTest($dic))->run();


### PR DESCRIPTION
Object's state is retrieved in `StateMachine::initialize()`, therefore `$this->setFiniteState` has to be called earlier in the constructor
